### PR TITLE
Enh 24617

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1285,7 +1285,6 @@ default: %(va)s
         ----------
         subplotparams: dict or SubplotParams, optional
                     New parameters of the subplot
-
         """
 
         kwargs = {"left": None, "bottom": None, "right": None,
@@ -1312,7 +1311,7 @@ default: %(va)s
         Return the parameters of the figure's subplot.
         """
         return self.subplotpars
-    
+
     def subplots_adjust(self, left=None, bottom=None, right=None, top=None,
                         wspace=None, hspace=None):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2318,6 +2318,10 @@ class SubFigure(FigureBase):
 
 
 @_docstring.interpd
+@_api.define_aliases({
+    "size_inches": ["figsize"],
+    "layout": ["layout_engine"]
+})
 class Figure(FigureBase):
     """
     The top level container for all the plot elements.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1277,6 +1277,42 @@ default: %(va)s
         self.stale = True
         return cb
 
+    def set_subplotpars(self, subplotparams = {}):
+        """
+        Modify the parameters of the figure's subplot.
+
+        Parameters:
+        ----------
+        subplotparams: dict or SubplotParams
+                    New parameters of the subplot
+
+        """
+        kwargs = {"left": None, "bottom": None, "right": None, 
+                  "top": None, "wspace": None, "hspace": None}
+        if isinstance(subplotparams, SubplotParams):
+            for key in kwargs:
+                kwargs[key] = getattr(subplotparams,key)
+        elif isinstance(subplotparams, dict):
+            for key in subplotparams.keys():
+                if key in kwargs:
+                    kwargs[key] = subplotparams[key]
+                else:
+                    _api.warn_external(
+                        f"'{key}' was ignored as it is not a valid key for" 
+                        " set_subplotpars;")
+        else:
+            raise TypeError(
+                "subplotpars must be a dictionary of keyword-argument pairs or"
+                " an instance of SubplotParams()")
+        self.subplots_adjust(**kwargs)
+        
+
+    def get_subplotpars(self):
+        """
+        Return the parameters of the figure's subplot.
+        """
+        return self.subplotpars
+    
     def subplots_adjust(self, left=None, bottom=None, right=None, top=None,
                         wspace=None, hspace=None):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1277,35 +1277,35 @@ default: %(va)s
         self.stale = True
         return cb
 
-    def set_subplotpars(self, subplotparams = {}):
+    def set_subplotpars(self, subplotparams={}):
         """
         Modify the parameters of the figure's subplot.
 
         Parameters:
         ----------
-        subplotparams: dict or SubplotParams
+        subplotparams: dict or SubplotParams, optional
                     New parameters of the subplot
 
         """
-        kwargs = {"left": None, "bottom": None, "right": None, 
+
+        kwargs = {"left": None, "bottom": None, "right": None,
                   "top": None, "wspace": None, "hspace": None}
         if isinstance(subplotparams, SubplotParams):
             for key in kwargs:
-                kwargs[key] = getattr(subplotparams,key)
+                kwargs[key] = getattr(subplotparams, key)
         elif isinstance(subplotparams, dict):
             for key in subplotparams.keys():
                 if key in kwargs:
                     kwargs[key] = subplotparams[key]
                 else:
                     _api.warn_external(
-                        f"'{key}' was ignored as it is not a valid key for" 
+                        f"'{key}' was ignored as it is not a valid key for"
                         " set_subplotpars;")
         else:
             raise TypeError(
                 "subplotpars must be a dictionary of keyword-argument pairs or"
                 " an instance of SubplotParams()")
         self.subplots_adjust(**kwargs)
-        
 
     def get_subplotpars(self):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2356,7 +2356,7 @@ class SubFigure(FigureBase):
 @_docstring.interpd
 @_api.define_aliases({
     "size_inches": ["figsize"],
-    "layout": ["layout_engine"]
+    "layout_engine": ["layout"]
 })
 class Figure(FigureBase):
     """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1279,9 +1279,9 @@ default: %(va)s
 
     def set_subplotpars(self, subplotparams={}):
         """
-        Modify the parameters of the figure's subplot.
+        Modify the subplot parameters.
 
-        Parameters:
+        Parameters
         ----------
         subplotparams: dict or SubplotParams, optional
                     New parameters of the subplot

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -681,8 +681,8 @@ def test_set_subplotpars():
     subplotparams = fig.get_subplotpars()
     default_dict = {"left": 0.125, "bottom": 0.1, "right": 0.9, "top": 0.9, 
                     "wspace": 0.2, "hspace": 0.2}
-    test_dict = {"left": 0.25, "bottom": 0.2, "right": 1.8, "top": 1.8 ,
-                 "wspace":0.4, "hspace":0.4}
+    test_dict = {"left": 0.25, "bottom": 0.2, "right": 1.8, "top": 1.8,
+                 "wspace": 0.4, "hspace": 0.4}
 
     # initial value of subplot params
     for key in subplotparams_keys:
@@ -698,7 +698,8 @@ def test_set_subplotpars():
     # invalid key error
     test_dict['foo'] = 'bar'
     with pytest.warns(UserWarning,
-                    match="'foo' was ignored as it is not a valid key for set_subplotpars;"):
+                      match="'foo' was ignored as it is not a valid key for "
+                      "set_subplotpars;"):
         fig.set_subplotpars(test_dict)
 
     # passing in a list instead of a dictionary or instance of SubplotParams()
@@ -709,10 +710,10 @@ def test_set_subplotpars():
         fig.set_subplotpars(['foo'])
 
     # left cant be bigger than or equl to right ValueError: left cannot be >= right
-    test_dict_left_greater_right = {"left": 2, "bottom": 0.2, "right": 1.8, 
-                                    "top": 1.8 , "wspace": 0.4, "hspace": 0.4}
+    test_dict_left_greater_right = {"left": 2, "bottom": 0.2, "right": 1.8,
+                                    "top": 1.8, "wspace": 0.4, "hspace": 0.4}
     with pytest.raises(ValueError,
-                    match="left cannot be >= right"):
+                       match="left cannot be >= right"):
         fig.set_subplotpars(test_dict_left_greater_right)
 
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -369,6 +369,15 @@ def test_set_fig_size():
     assert fig.get_figheight() == 3
 
 
+def test_get_figsize():
+    fig = plt.figure()
+    fig.set_size_inches((1, 3))
+
+    assert fig.get_figsize()[0] == 1
+    assert fig.get_figsize()[1] == 3
+
+
+
 def test_axes_remove():
     fig, axs = plt.subplots(2, 2)
     axs[-1, -1].remove()

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -377,7 +377,6 @@ def test_get_figsize():
     assert fig.get_figsize()[1] == 3
 
 
-
 def test_axes_remove():
     fig, axs = plt.subplots(2, 2)
     axs[-1, -1].remove()

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -591,21 +591,19 @@ def test_valid_layouts():
     assert fig.get_constrained_layout()
 
 def test_valid_layouts_with_alias():
-   fig = Figure(layout=None)
-   assert not fig.get_tight_layout()
-   assert not fig.get_constrained_layout()
+    fig = Figure(layout=None)
+    assert not fig.get_tight_layout()
+    assert not fig.get_constrained_layout()
 
+    fig.set_layout('tight')
+    assert isinstance(fig.get_layout(), TightLayoutEngine)
+    assert fig.get_tight_layout()
+    assert not fig.get_constrained_layout()
 
-   fig.set_layout('tight')
-   assert isinstance(fig.get_layout(), TightLayoutEngine)
-   assert fig.get_tight_layout()
-   assert not fig.get_constrained_layout()
-
-
-   fig.set_layout('constrained')
-   assert isinstance(fig.get_layout(), ConstrainedLayoutEngine)
-   assert not fig.get_tight_layout()
-   assert fig.get_constrained_layout()
+    fig.set_layout('constrained')
+    assert isinstance(fig.get_layout(), ConstrainedLayoutEngine)
+    assert not fig.get_tight_layout()
+    assert fig.get_constrained_layout()
 
 def test_invalid_layouts():
     fig, ax = plt.subplots(layout="constrained")

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -676,43 +676,44 @@ def test_get_subplotpars():
 
 def test_set_subplotpars():
     # setup
-     subplotparams_keys = ["left", "bottom", "right", "top", "wspace", "hspace"]
-     fig = plt.figure()
-     subplotparams = fig.get_subplotpars()
-     default_dict = {"left":0.125, "bottom":0.1, "right":0.9, "top":0.9 , "wspace":0.2, "hspace":0.2}
-     test_dict = {"left":0.25, "bottom":0.2, "right":1.8, "top":1.8 , "wspace":0.4, "hspace":0.4}
+    subplotparams_keys = ["left", "bottom", "right", "top", "wspace", "hspace"]
+    fig = plt.figure()
+    subplotparams = fig.get_subplotpars()
+    default_dict = {"left": 0.125, "bottom": 0.1, "right": 0.9, "top": 0.9, 
+                    "wspace": 0.2, "hspace": 0.2}
+    test_dict = {"left": 0.25, "bottom": 0.2, "right": 1.8, "top": 1.8 ,
+                 "wspace":0.4, "hspace":0.4}
 
     # initial value of subplot params
-     for key in subplotparams_keys:
-         attr = getattr(subplotparams, key)
-         assert attr == default_dict[key]
+    for key in subplotparams_keys:
+        attr = getattr(subplotparams, key)
+        assert attr == default_dict[key]
 
     # set subplotpars to test_dict and check that the values are changed
-     fig.set_subplotpars(test_dict)
-     updated_subplotparams = fig.get_subplotpars()
-     for key, value in test_dict.items():
-         assert getattr(updated_subplotparams, key) == value
+    fig.set_subplotpars(test_dict)
+    updated_subplotparams = fig.get_subplotpars()
+    for key, value in test_dict.items():
+        assert getattr(updated_subplotparams, key) == value
 
     # invalid key error
-     test_dict['foo'] = 'bar'
-     with pytest.warns(UserWarning,
-                       match="'foo' was ignored as it is not a valid key for set_subplotpars;"):
-         fig.set_subplotpars(test_dict)
+    test_dict['foo'] = 'bar'
+    with pytest.warns(UserWarning,
+                    match="'foo' was ignored as it is not a valid key for set_subplotpars;"):
+        fig.set_subplotpars(test_dict)
 
     # passing in a list instead of a dictionary or instance of SubplotParams()
-     with pytest.raises(TypeError,
+    with pytest.raises(TypeError,
                         match="subplotpars must be a dictionary of "
                         "keyword-argument pairs or "
                         "an instance of SubplotParams()"):
-         fig.set_subplotpars(['foo'])
+        fig.set_subplotpars(['foo'])
 
     # left cant be bigger than or equl to right ValueError: left cannot be >= right
-     test_dict_left_greater_right = {"left":2, "bottom":0.2, "right":1.8, "top":1.8 , "wspace":0.4, "hspace":0.4}
-     with pytest.raises(ValueError,
+    test_dict_left_greater_right = {"left": 2, "bottom": 0.2, "right": 1.8, 
+                                    "top": 1.8 , "wspace": 0.4, "hspace": 0.4}
+    with pytest.raises(ValueError,
                     match="left cannot be >= right"):
-         fig.set_subplotpars(test_dict_left_greater_right)
-
-
+        fig.set_subplotpars(test_dict_left_greater_right)
 
 
 @check_figures_equal(extensions=["png", "pdf"])

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -590,6 +590,7 @@ def test_valid_layouts():
     assert not fig.get_tight_layout()
     assert fig.get_constrained_layout()
 
+
 def test_valid_layouts_with_alias():
     fig = Figure(layout=None)
     assert not fig.get_tight_layout()
@@ -604,6 +605,7 @@ def test_valid_layouts_with_alias():
     assert isinstance(fig.get_layout(), ConstrainedLayoutEngine)
     assert not fig.get_tight_layout()
     assert fig.get_constrained_layout()
+
 
 def test_invalid_layouts():
     fig, ax = plt.subplots(layout="constrained")
@@ -679,7 +681,7 @@ def test_set_subplotpars():
     subplotparams_keys = ["left", "bottom", "right", "top", "wspace", "hspace"]
     fig = plt.figure()
     subplotparams = fig.get_subplotpars()
-    default_dict = {"left": 0.125, "bottom": 0.1, "right": 0.9, "top": 0.9, 
+    default_dict = {"left": 0.125, "bottom": 0.1, "right": 0.9, "top": 0.9,
                     "wspace": 0.2, "hspace": 0.2}
     test_dict = {"left": 0.25, "bottom": 0.2, "right": 1.8, "top": 1.8,
                  "wspace": 0.4, "hspace": 0.4}

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -358,6 +358,18 @@ def test_set_fig_size():
     assert fig.get_figwidth() == 1
     assert fig.get_figheight() == 3
 
+        # check using alias figsize
+    fig.set_figsize(2, 4)
+    assert fig.get_figwidth() == 2
+    assert fig.get_figheight() == 4
+
+    # check using tuple to first argument and alias figsize
+    fig.set_figsize((1, 3))
+    assert fig.get_figwidth() == 1
+    assert fig.get_figheight() == 3
+
+
+
 
 def test_axes_remove():
     fig, axs = plt.subplots(2, 2)
@@ -580,6 +592,22 @@ def test_valid_layouts():
     assert not fig.get_tight_layout()
     assert fig.get_constrained_layout()
 
+def test_valid_layouts_with_alias():
+   fig = Figure(layout=None)
+   assert not fig.get_tight_layout()
+   assert not fig.get_constrained_layout()
+
+
+   fig.set_layout('tight')
+   assert isinstance(fig.get_layout(), TightLayoutEngine)
+   assert fig.get_tight_layout()
+   assert not fig.get_constrained_layout()
+
+
+   fig.set_layout('constrained')
+   assert isinstance(fig.get_layout(), ConstrainedLayoutEngine)
+   assert not fig.get_tight_layout()
+   assert fig.get_constrained_layout()
 
 def test_invalid_layouts():
     fig, ax = plt.subplots(layout="constrained")

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -358,7 +358,7 @@ def test_set_fig_size():
     assert fig.get_figwidth() == 1
     assert fig.get_figheight() == 3
 
-        # check using alias figsize
+    # check using alias figsize
     fig.set_figsize(2, 4)
     assert fig.get_figwidth() == 2
     assert fig.get_figheight() == 4
@@ -367,8 +367,6 @@ def test_set_fig_size():
     fig.set_figsize((1, 3))
     assert fig.get_figwidth() == 1
     assert fig.get_figheight() == 3
-
-
 
 
 def test_axes_remove():
@@ -670,6 +668,53 @@ def test_layout_change_warning(layout):
     fig, ax = plt.subplots(layout=layout)
     with pytest.warns(UserWarning, match='The figure layout has changed to'):
         plt.tight_layout()
+
+
+def test_get_subplotpars():
+    fig = plt.figure()
+    # check get method works
+    assert fig.get_subplotpars() == fig.subplotpars
+
+
+def test_set_subplotpars():
+    # setup
+     subplotparams_keys = ["left", "bottom", "right", "top", "wspace", "hspace"]
+     fig = plt.figure()
+     subplotparams = fig.get_subplotpars()
+     default_dict = {"left":0.125, "bottom":0.1, "right":0.9, "top":0.9 , "wspace":0.2, "hspace":0.2}
+     test_dict = {"left":0.25, "bottom":0.2, "right":1.8, "top":1.8 , "wspace":0.4, "hspace":0.4}
+
+    # initial value of subplot params
+     for key in subplotparams_keys:
+         attr = getattr(subplotparams, key)
+         assert attr == default_dict[key]
+
+    # set subplotpars to test_dict and check that the values are changed
+     fig.set_subplotpars(test_dict)
+     updated_subplotparams = fig.get_subplotpars()
+     for key, value in test_dict.items():
+         assert getattr(updated_subplotparams, key) == value
+
+    # invalid key error
+     test_dict['foo'] = 'bar'
+     with pytest.warns(UserWarning,
+                       match="'foo' was ignored as it is not a valid key for set_subplotpars;"):
+         fig.set_subplotpars(test_dict)
+
+    # passing in a list instead of a dictionary or instance of SubplotParams()
+     with pytest.raises(TypeError,
+                        match="subplotpars must be a dictionary of "
+                        "keyword-argument pairs or "
+                        "an instance of SubplotParams()"):
+         fig.set_subplotpars(['foo'])
+
+    # left cant be bigger than or equl to right ValueError: left cannot be >= right
+     test_dict_left_greater_right = {"left":2, "bottom":0.2, "right":1.8, "top":1.8 , "wspace":0.4, "hspace":0.4}
+     with pytest.raises(ValueError,
+                    match="left cannot be >= right"):
+         fig.set_subplotpars(test_dict_left_greater_right)
+
+
 
 
 @check_figures_equal(extensions=["png", "pdf"])


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
