### PR TITLE
[Bug 24605] updated doc string

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -174,7 +174,8 @@ def check_shape(_shape, **kwargs):
 
 def check_tuple(**kwargs):
     """
-    *kwargs* must consist of a tuple of length 2.
+    *kwargs* must consist of a tuple of length 2 containing two floating 
+    point numbers.
 
     Examples
     --------

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -679,11 +679,17 @@ class Legend(Artist):
         a.set_transform(self.get_transform())
 
     def _set_loc(self, loc):
+        """
+        Sets loc to the two floats passed in loc.
+
+        Raises a ValueError if loc is not a tuple containing two floats.
+        """   
         # find_offset function will be provided to _legend_box and
         # _legend_box will draw itself at the location of the return
         # value of the find_offset.
-        self._loc_used_default = False
-        loc = _api.check_tuple(loc=loc)
+        self._loc_used_default = False        
+        loc = _api.check_tuple(loc=loc)  
+
         self._loc_real = loc
         self.stale = True
         self._legend_box.set_offset(self._findoffset)


### PR DESCRIPTION
Updated the doc string for _set_loc

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
