### PR TITLE
Enh 20896

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1392,8 +1392,8 @@ class Normalize:
         always eq false such as comparing a TwoSlopeNorm with a CenteredNorm
         """
         #Cheeky List Comprehension
-        selfItems = [(attribute,value) for attribute, value in self.__dict__.items()]
-        otherItems = [(attribute,value) for attribute, value in other.__dict__.items()]
+        selfItems = {(attribute,value) for attribute, value in self.__dict__.items()}
+        otherItems = {(attribute,value) for attribute, value in other.__dict__.items()}
         return selfItems == otherItems
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1380,6 +1380,21 @@ class Normalize:
     def scaled(self):
         """Return whether vmin and vmax are set."""
         return self.vmin is not None and self.vmax is not None
+    
+
+    def __eq__(self, other):
+        """Return the whether this norm and another norm share
+        the same attributes. 
+        
+        Examples include that Normalize of the same type with 
+        same settings such as a TwoSlopeNorm(0, -1, 1), will == true.
+        However comparisong of Normalizes without like attributes will
+        always eq false such as comparing a TwoSlopeNorm with a CenteredNorm
+        """
+        #Cheeky List Comprehension
+        selfItems = [(attribute,value) for attribute, value in self.__dict__.items()]
+        otherItems = [(attribute,value) for attribute, value in other.__dict__.items()]
+        return selfItems == otherItems
 
 
 class TwoSlopeNorm(Normalize):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1390,6 +1390,10 @@ class Normalize:
         same settings such as a TwoSlopeNorm(0, -1, 1), will == true.
         However comparisong of Normalizes without like attributes will
         always eq false such as comparing a TwoSlopeNorm with a CenteredNorm
+
+        Explicitly even if two norms would return the same normalized results
+        we say that two norms are not equal if their attribute value pairs are
+        not equal, due to the chance of "lucky input".
         """
         #Cheeky List Comprehension
         selfItems = {(attribute,value) for attribute, value in self.__dict__.items()}

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1550,6 +1550,24 @@ def test_make_norm_from_scale_name():
         mscale.LogitScale, mcolors.Normalize)
     assert logitnorm.__name__ == logitnorm.__qualname__ == "LogitScaleNorm"
 
+# ---- Norm equality checks
+def test_like_norms_same():
+    #Norms should pass if exactly the same
+    norm1 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
+    norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
+    assert norm1 == norm2
+
+def test_like_norms_diff():
+    #Same type of norms with different values should false
+    norm1 = mcolors.SymLogNorm(3, vmax=8, linscale=2, base=np.e)
+    norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
+    assert norm1 != norm2
+
+def test_unlike_norms_similar():
+    #Norms that use different attributes, but same vlaues should false
+    norm1 = mcolors.CenteredNorm(3, vmax=5, vcenter=1, halfrange=np.e,)
+    norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
+    assert norm1 != norm2
 
 def test_color_sequences():
     # basic access

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1550,12 +1550,13 @@ def test_make_norm_from_scale_name():
         mscale.LogitScale, mcolors.Normalize)
     assert logitnorm.__name__ == logitnorm.__qualname__ == "LogitScaleNorm"
 
-# ---- Norm equality checks
+
 def test_like_norms_same():
     #Norms should pass if exactly the same
     norm1 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
     norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
     assert norm1 == norm2
+
 
 def test_like_norms_same_diff_order():
     #Norms should pass if exactly the same
@@ -1570,11 +1571,13 @@ def test_like_norms_diff():
     norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
     assert norm1 != norm2
 
+
 def test_unlike_norms_similar():
     #Norms that use different attributes, but same vlaues should false
     norm1 = mcolors.CenteredNorm(3, vmax=5, vcenter=1, halfrange=np.e,)
     norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
     assert norm1 != norm2
+
 
 def test_color_sequences():
     # basic access

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1557,6 +1557,13 @@ def test_like_norms_same():
     norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
     assert norm1 == norm2
 
+def test_like_norms_same_diff_order():
+    #Norms should pass if exactly the same
+    norm1 = mcolors.SymLogNorm(3, linscale=1, vmax=5, base=np.e)
+    norm2 = mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e)
+    assert norm1 == norm2
+
+
 def test_like_norms_diff():
     #Same type of norms with different values should false
     norm1 = mcolors.SymLogNorm(3, vmax=8, linscale=2, base=np.e)


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes** NOT FOR RELEASE
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
